### PR TITLE
Public sliderInstance to have control over the tiny slider

### DIFF
--- a/projects/ngx-tiny-slider/src/lib/ngx-tiny-slider.component.ts
+++ b/projects/ngx-tiny-slider/src/lib/ngx-tiny-slider.component.ts
@@ -16,7 +16,7 @@ export class NgxTinySliderComponent implements OnInit, OnDestroy {
   @Input() config: NgxTinySliderSettingsInterface;
   @ViewChild('slideItems') slideItemsContainerRef;
 
-  private sliderInstance;
+  public sliderInstance;
   private aliveObservable = true;
 
   public domReady = new Subject();


### PR DESCRIPTION
Hi!

I think it is better to leave the `sliderInstance` instance public to release control over the tiny slider, example, event listen.

[]'s